### PR TITLE
Support parallel execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 
 build/
 .fsdocs/
+
+.fake

--- a/src/FSLint.Tests/B2R2.FSLint.Tests.fsproj
+++ b/src/FSLint.Tests/B2R2.FSLint.Tests.fsproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="ParallelPerfTests.fs" />
     <Compile Include="MSTestSettings.fs" />
     <Compile Include="Constants.fs" />
     <Compile Include="LineTests.fs" />

--- a/src/FSLint.Tests/ParallelPerfTests.fs
+++ b/src/FSLint.Tests/ParallelPerfTests.fs
@@ -1,0 +1,59 @@
+namespace B2R2.FSLint.Tests
+
+open System
+open System.IO
+open System.Diagnostics
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open B2R2.FSLint
+open B2R2.FSLint.Program 
+
+
+type MockLinter(delayMs:int) =
+    interface ILintable with
+        member _.Lint(_path, _txt) =
+            let sw = Stopwatch.StartNew()
+            let mutable acc = 0
+            while sw.ElapsedMilliseconds < int64 delayMs do
+                acc <- acc + 1
+            if acc = Int32.MinValue then () 
+
+[<TestClass>]
+type ParallelPerfTests() =
+
+    let createTempFsFiles (n:int) =
+        let dir = Path.Combine(Path.GetTempPath(), "FSLintPerf_" + Guid.NewGuid().ToString("N"))
+        Directory.CreateDirectory(dir) |> ignore
+        for i in 1..n do
+            File.WriteAllText(Path.Combine(dir, $"file_{i}.fs"), "let x = 1")
+        dir, Directory.GetFiles(dir, "*.fs")
+
+    let cleanup dir =
+        try Directory.Delete(dir, true) with _ -> ()
+
+    [<TestMethod>]
+    member _.Parallel_is_faster_than_sequential() =
+        let nFiles = 32
+        let delayPerFileMs = 40
+        let dir, files = createTempFsFiles nFiles
+        try
+            let linter = MockLinter(delayPerFileMs) :> ILintable
+
+            // (1) 직렬 실행
+            let swSeq = Stopwatch.StartNew()
+            files |> Array.iteri (fun i path -> tryLintToBuffer linter i path |> ignore)
+            swSeq.Stop()
+            let tSeq = swSeq.ElapsedMilliseconds
+
+            // (2) 병렬 실행 (main 함수에서 쓰는 runParallelPreservingOrder 호출)
+            let swPar = Stopwatch.StartNew()
+            let hasErrors = runParallelPreservingOrder linter files
+            swPar.Stop()
+            let tPar = swPar.ElapsedMilliseconds
+
+            
+            Console.WriteLine($"Sequential: {tSeq} ms, Parallel: {tPar} ms, hasErrors={hasErrors}")
+
+            // 검증: 병렬이 직렬보다 빨라야 함
+            Assert.IsTrue(tPar < tSeq, $"Expected parallel < sequential, but got Seq={tSeq}, Par={tPar}")
+        finally
+            cleanup dir


### PR DESCRIPTION
## 1. Background and Goal
- 기존 `Program.fs`의 `main` 함수는 파일을 **직렬(sequential)** 방식으로 검사하고 있어 성능에 한계가 있었습니다.  
- 이번 과제의 목표는 다음과 같습니다:
  1. 파일 검사를 **병렬(parallel)** 구조로 변경하여 성능 개선.
  2. 병렬 실행 시에도 **출력 순서가 꼬이지 않도록 보존**. (Console에 직접 출력하는 형식으로 되어있어서 불확실)
  3. 예외 발생 시 프로그램이 중단되지 않고 **결과를 안전하게 수집**. 

---

## 2. Design Decisions and Implementation

### 2.1 `LintOutcome` 정의
```fsharp
type LintOutcome =
  { Index: int
    Path: string
    Ok: bool
    Log: string }
```
- 파일 하나의 검사 결과를 담는 record 타입.  
- `Index`를 통해 순서를 보존하고, `Ok`로 성공 여부를 표시.  
- 병렬 실행 시에도 로그를 안정적으로 보관할 수 있도록 설계.  

---

### 2.2 파일 수집 함수
- `getFsFiles`: 검사 대상 `.fs` 파일만 정렬된 배열로 반환.  
- `getProjOrSlnFiles`: `.fsproj`, `.sln` 파일을 수집.  

---

### 2.3 `tryLintToBuffer`
```fsharp
let tryLintToBuffer (linter: ILintable) (index: int) (path: string) : LintOutcome
```
- 파일 하나를 검사하고 결과를 `LintOutcome`에 포장.  
- 예외 발생 시에도 `Ok=false`로 안전하게 결과를 반환.  

---

### 2.4 `runParallelPreservingOrder`
```fsharp
let runParallelPreservingOrder (linter: ILintable) (paths: string array)
```
- 여러 파일을 `Async.Parallel`로 동시에 검사.  
- 검사 후 `Index` 기준으로 재정렬하여 원래 순서를 보존.  
- 반환값은 오류 발생 여부(`true`/`false`).  

---

### 2.5 `main` 함수
- 인자가 파일이면 단일 파일 검사.  
- 인자가 디렉토리면:  
  - 프로젝트 파일(`.fsproj`, `.sln`) → 직렬 검사.  
  - 소스 파일(`.fs`) → `runParallelPreservingOrder`를 호출하여 병렬 검사.  
- 성공 시 `0`, 오류 발생 시 `1`을 반환.  

---

## 3. Testing Strategy

### 3.1 성능 비교 테스트
- 두 가지 실행 방식을 비교:  
  - **직렬**: `tryLintToBuffer` + `Array.iter`.  
  - **병렬**: `runParallelPreservingOrder`.  
- **결과**: 병렬 실행이 직렬 실행보다 더 빠른 것을 확인.  

---

## 4. Relation to ROP (Railway Oriented Programming)
- 현재 구조는 부분적으로 ROP:  
  - 예외를 값(`LintOutcome`)으로 변환 → 안전하게 파이프라인을 이어감.  
  - 병렬 실행에서도 프로그램이 중단되지 않고 결과를 수집.  

- **향후 발전 방향**:  
  - `LintOutcome`을 Result 타입 기반으로 개선.  

---

## 5. Conclusion
- 병렬 실행을 통해 성능 개선을 확인. 
- 예외를 값으로 캡처하는 구조를 통해 병렬 실행 환경에서도 안정적인 동작 보장.  
