### PR TITLE
Feature/detect low quality code triple quote

### DIFF
--- a/src/FSLint.Tests/AppTests.fs
+++ b/src/FSLint.Tests/AppTests.fs
@@ -7,33 +7,41 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type AppTests() =
 
-  let goodListSpaceInfixTest = """
+  let goodListSpaceInfixTest =
+    """
 [ this.Address + uint64 this.Length + this.Name ]
 """
 
-  let badListSpaceInfixTest = """
+  let badListSpaceInfixTest =
+    """
 [ this.Address +  uint64 this.Length + this.Name ]
 """
 
-  let goodListAppIndexerTest = """
+  let goodListAppIndexerTest =
+    """
 [ lifter.File.RawBytes[ptr.Offset] ]
 """
 
-  let badListAppIndexerTest = """
+  let badListAppIndexerTest =
+    """
 [ lifter.File.RawBytes[ ptr.Offset ] ]
 """
 
-  let goodListAppIndexerInRangeTest = """
+  let goodListAppIndexerInRangeTest =
+    """
 good[1..]
 """
 
-  let badListAppIndexerInRangeTest = """
+  let badListAppIndexerInRangeTest =
+    """
 bad[ 1.. ]
 """
 
-  let goodListSpaceFunAppTest = """[ fn 1 2 3 x ]"""
+  let goodListSpaceFunAppTest =
+    """[ fn 1 2 3 x ]"""
 
-  let badListSpaceFunAppTest = """[ fn  1 2 3 x ]"""
+  let badListSpaceFunAppTest =
+    """[ fn  1 2 3 x ]"""
 
   [<TestMethod>]
   member _.``[App] List Space Before and After Infix Test``() =

--- a/src/FSLint.Tests/ArgumentAssignmentTests.fs
+++ b/src/FSLint.Tests/ArgumentAssignmentTests.fs
@@ -7,9 +7,11 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type AssignmentTests() =
 
-  let goodNamedArgumentSpacingTest = """func (param = value)"""
+  let goodNamedArgumentSpacingTest =
+    """func (param = value)"""
 
-  let badNamedArgumentSpacingTest = """func (param=value)"""
+  let badNamedArgumentSpacingTest =
+    """func (param=value)"""
 
 
   [<TestMethod>]

--- a/src/FSLint.Tests/ArrayOrListTests.fs
+++ b/src/FSLint.Tests/ArrayOrListTests.fs
@@ -9,90 +9,118 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ArrayOrListTests() =
 
-  let goodEmptyTest = """[]"""
+  let goodEmptyTest =
+    """[]"""
 
-  let badEmptyTest = """[ ]"""
+  let badEmptyTest =
+    """[ ]"""
 
-  let goodArrayEmptyTest = """[||]"""
+  let goodArrayEmptyTest =
+    """[||]"""
 
-  let badArrayEmptyTest = """[| |]"""
+  let badArrayEmptyTest =
+    """[| |]"""
 
-  let goodBracketSpacingTest = """[ 1; 2; 3; 4 ]"""
+  let goodBracketSpacingTest =
+    """[ 1; 2; 3; 4 ]"""
 
-  let badBracketSpacingTest = """[1; 2; 3; 4]"""
+  let badBracketSpacingTest =
+    """[1; 2; 3; 4]"""
 
-  let goodArrayBracketSpacingTest = """[| 1; 2; 3; 4 |]"""
+  let goodArrayBracketSpacingTest =
+    """[| 1; 2; 3; 4 |]"""
 
-  let badArrayBracketSpacingTest = """[|1; 2; 3; 4|]"""
+  let badArrayBracketSpacingTest =
+    """[|1; 2; 3; 4|]"""
 
-  let goodElementSpacingTest = """[ 1; 2 ]"""
+  let goodElementSpacingTest =
+    """[ 1; 2 ]"""
 
-  let badNoWhitespaceBetweenElementsTest = """[ 1;2 ]"""
+  let badNoWhitespaceBetweenElementsTest =
+    """[ 1;2 ]"""
 
-  let badTooMuchWhitespaceBetweenElementsTest = """[ 1;  2 ]"""
+  let badTooMuchWhitespaceBetweenElementsTest =
+    """[ 1;  2 ]"""
 
-  let badWhitespaceBeforeSeparatorTest = """[ 1 ;2 ]"""
+  let badWhitespaceBeforeSeparatorTest =
+    """[ 1 ;2 ]"""
 
-  let goodRangeOperatorTest = """[ 1 .. 10 ]"""
+  let goodRangeOperatorTest =
+    """[ 1 .. 10 ]"""
 
-  let badRangeOperatorTest = """[ 1..10 ]"""
+  let badRangeOperatorTest =
+    """[ 1..10 ]"""
 
-  let goodRangeOperatorWithIdentTest = """[ startIdent .. endIdent ]"""
+  let goodRangeOperatorWithIdentTest =
+    """[ startIdent .. endIdent ]"""
 
-  let badRangeOperatorWithIdentTest = """[ startIdent..endIdent ]"""
+  let badRangeOperatorWithIdentTest =
+    """[ startIdent..endIdent ]"""
 
-  let goodRangeOperatorWithStepTest = """[ 1 .. 2 .. 10 ]"""
+  let goodRangeOperatorWithStepTest =
+    """[ 1 .. 2 .. 10 ]"""
 
-  let badRangeOperatorWithStepTest = """[ 1 ..2.. 10 ]"""
+  let badRangeOperatorWithStepTest =
+    """[ 1 ..2.. 10 ]"""
 
-  let goodRangeOperatorWithStepAndIdentTest = """
+  let goodRangeOperatorWithStepAndIdentTest =
+    """
 [ startIdent .. 2 .. endIdent ]
 """
 
-  let badRangeOperatorWithStepAndIdentTest = """
+  let badRangeOperatorWithStepAndIdentTest =
+    """
 [ startIdent..2 .. endIdent ]
 """
 
-  let goodCommentPositionTest = """
+  let goodCommentPositionTest =
+    """
 [ 1; 2; 3 (* Good *) ]
 """
 
-  let badCommentPositionTest = """
+  let badCommentPositionTest =
+    """
 [ 1; 2; 3(* Bad *) ]
 """
 
-  let goodMultiLineBracketSpacingTest = """
+  let goodMultiLineBracketSpacingTest =
+    """
 [ 1
   2
   3 ]
 """
 
-  let badMultiLineBracketSpacingTest = """
+  let badMultiLineBracketSpacingTest =
+    """
 [1
  2
  3 ]
 """
 
-  let goodArrayMultiLineBracketSpacingTest = """
+  let goodArrayMultiLineBracketSpacingTest =
+    """
 [| 1
    2
    3 |]
 """
 
-  let badArrayMultiLineBracketSpacingTest = """
+  let badArrayMultiLineBracketSpacingTest =
+    """
 [|1
   2
   3 |]
 """
 
-  let goodOpeningBracketInlineWithLetTest = """
+  let goodOpeningBracketInlineWithLetTest =
+    """
 let good =
  [ 1
    2
    3 ]
 """
 
-  let badOpeningBracketInlineWithLetTest = """
+  let badOpeningBracketInlineWithLetTest =
+    """
 let bad = [
   1
   2
@@ -100,78 +128,93 @@ let bad = [
 ]
 """
 
-  let goodSingleElementPerLineTest = """
+  let goodSingleElementPerLineTest =
+    """
 [ 1
   2
   3
   4 ]
 """
 
-  let badSingleElementPerLineTest = """
+  let badSingleElementPerLineTest =
+    """
 [ 1; 2
   3; 4 ]
 """
 
-  let goodSeparatorNotInLineEndingTest = """
+  let goodSeparatorNotInLineEndingTest =
+    """
 [ 1
   2
   3 ]
 """
 
-  let badSeparatorNotInLineEndingTest = """
+  let badSeparatorNotInLineEndingTest =
+    """
 [ 1
   2;
   3 ]
 """
 
-  let goodMultiLineCommentPositionTest = """
+  let goodMultiLineCommentPositionTest =
+    """
 [ 1
   2
   3 (* Good *) ]
 """
 
-  let badMultiLineCommentPositionTest = """
+  let badMultiLineCommentPositionTest =
+    """
 [ 1
   2
   3(* Bad *) ]
 """
 
-  let goodNestedBracketSpacingTest = """
+  let goodNestedBracketSpacingTest =
+    """
 [ [ 1; 2 ]; [ 3; 4 ] ]
 """
 
-  let goodNestedBracketSpacingMultiLineTest = """
+  let goodNestedBracketSpacingMultiLineTest =
+    """
 [ [ 1; 2 ]
   [ 3; 4 ] ]
 """
 
-  let badNestedBracketSpacingTest = """
+  let badNestedBracketSpacingTest =
+    """
 [ [ 1; 2]; [ 3; 4 ] ]
 """
 
-  let badNestedBracketSpacingMultiLineTest = """
+  let badNestedBracketSpacingMultiLineTest =
+    """
 [ [ 1; 2]
   [ 3; 4 ] ]
 """
 
-  let badNestedElementSpacingTest = """
+  let badNestedElementSpacingTest =
+    """
 [ [ 1;2 ]; [ 3; 4 ] ]
 """
 
-  let badNestedElementSpacingMultiLineTest = """
+  let badNestedElementSpacingMultiLineTest =
+    """
 [ [ 1;2 ]
   [ 3; 4 ] ]
 """
 
-  let goodNestedMixBracketSpacingTest = """
+  let goodNestedMixBracketSpacingTest =
+    """
 [ [| 1; 2 |]; [| 3; 4 |] ]
 """
 
-  let badNestedMixBracketSpacingTest = """
+  let badNestedMixBracketSpacingTest =
+    """
 [ [| 1; 2|]; [| 3; 4 |] ]
 """
 
-  let badNestedMixElementSpacingTest = """
+  let badNestedMixElementSpacingTest =
+    """
 [ [| 1;2 |]; [| 3; 4 |] ]
 """
 

--- a/src/FSLint.Tests/ClassDefinitionTests.fs
+++ b/src/FSLint.Tests/ClassDefinitionTests.fs
@@ -7,17 +7,20 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ClassDefinitionTests() =
 
-  let goodImplicitCtorTest = """
+  let goodImplicitCtorTest =
+    """
 type TestClass(param1: string, param2: int) =
   member _.Param1 = param1
 """
 
-  let badImplicitCtorTest = """
+  let badImplicitCtorTest =
+    """
 type TestClass (param1: string, param2: int) =
   member _.Param1 = param1
 """
 
-  let goodImplicitInheritTest = """
+  let goodImplicitInheritTest =
+    """
 type BaseClass(value: int) =
   member _.Value = value
 
@@ -26,7 +29,8 @@ type DerivedClass(x: int, y: string) =
   member _.Y = y
 """
 
-  let badImplicitInheritTest = """
+  let badImplicitInheritTest =
+    """
 type BaseClass(value: int) =
   member _.Value = value
 
@@ -35,7 +39,8 @@ type DerivedClass(x: int, y: string) =
   member _.Y = y
 """
 
-  let goodExplicitInheritTest = """
+  let goodExplicitInheritTest =
+    """
 type BaseClass(value: int) =
   member _.Value = value
 
@@ -45,7 +50,8 @@ type DerivedClass() =
   member _.Helper = helper
 """
 
-  let badExplicitInheritTest = """
+  let badExplicitInheritTest =
+    """
 type BaseClass(value: int) =
   member _.Value = value
 
@@ -55,7 +61,8 @@ type DerivedClass() =
   member _.Helper = helper
 """
 
-  let goodNestedInheritTest = """
+  let goodNestedInheritTest =
+    """
 type GrandParent(name: string) =
   member _.Name = name
 
@@ -68,7 +75,8 @@ type Child(name: string, age: int, grade: int) =
   member _.Grade = grade
 """
 
-  let badNestedInheritTest = """
+  let badNestedInheritTest =
+    """
 type GrandParent(name: string) =
   member _.Name = name
 
@@ -81,7 +89,8 @@ type Child(name: string, age: int, grade: int) =
   member _.Grade = grade
 """
 
-  let goodMixedCaseTest = """
+  let goodMixedCaseTest =
+    """
 type ComplexClass(initialValue: int) =
   let mutable counter = 0
   inherit System.Object()
@@ -89,7 +98,8 @@ type ComplexClass(initialValue: int) =
   member _.Increment() = counter <- counter + 1
 """
 
-  let badMixedCaseTest = """
+  let badMixedCaseTest =
+    """
 type ComplexClass (initialValue: int) =
   let mutable counter = 0
   inherit System.Object ()

--- a/src/FSLint.Tests/ClassMemberTests.fs
+++ b/src/FSLint.Tests/ClassMemberTests.fs
@@ -7,42 +7,50 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ClassMemberTests() =
 
-  let goodSpacingInfixParenTest = """
+  let goodSpacingInfixParenTest =
+    """
 type TestClass() =
   static member inline (+) (param1, param2) = value
 """
 
-  let badSpacingInfixParenTest = """
+  let badSpacingInfixParenTest =
+    """
 type TestClass() =
   static member inline (+)(param1, param2) = value
 """
 
-  let goodSpacingFunctionParenTest = """
+  let goodSpacingFunctionParenTest =
+    """
 type TestClass() =
   member _.Create(param1, param2) = value
 """
 
-  let badSpacingFunctionParenTest = """
+  let badSpacingFunctionParenTest =
+    """
 type TestClass() =
   member _.Create (param1, param2) = value
 """
 
-  let goodSelfIdentifierUnderscoreTest = """
+  let goodSelfIdentifierUnderscoreTest =
+    """
 type Class() =
   member _.A(p1, p2) = _.B()
 """
 
-  let badSelfIdentifierUnderscoreTest = """
+  let badSelfIdentifierUnderscoreTest =
+    """
 type Class() =
   member __.A(p1, p2) = __.B()
 """
 
-  let goodSelfIdentifierUnusedTest = """
+  let goodSelfIdentifierUnusedTest =
+    """
 type Class() =
   member this.A(p1, p2) = this.B()
 """
 
-  let badSelfIdentifierUnusedTest = """
+  let badSelfIdentifierUnusedTest =
+    """
 type Class() =
   member this.A(p1, p2) = B()
 """

--- a/src/FSLint.Tests/DeclarationTests.fs
+++ b/src/FSLint.Tests/DeclarationTests.fs
@@ -7,18 +7,21 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type DeclarationTests() =
 
-  let goodTopBindingSpacingTest = """
+  let goodTopBindingSpacingTest =
+    """
 let foo = 1
 
 let bar = 2
 """
 
-  let badTopBindingSpacingTest = """
+  let badTopBindingSpacingTest =
+    """
 let foo = 1
 let bar = 2
 """
 
-  let badTopBindingTooMuchSpacingTest = """
+  let badTopBindingTooMuchSpacingTest =
+    """
 let foo = 1
 
 

--- a/src/FSLint.Tests/FunctionBodyTests.fs
+++ b/src/FSLint.Tests/FunctionBodyTests.fs
@@ -7,14 +7,16 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type FunctionBodyTests() =
 
-  let goodEmptyNewLineTest = """
+  let goodEmptyNewLineTest =
+    """
 let fn () =
   let x = 1
   let y = 2
   x + y
 """
 
-  let badEmptyNewLineTest = """
+  let badEmptyNewLineTest =
+    """
 let fn () =
   let x = 1
   let y = 2
@@ -22,7 +24,8 @@ let fn () =
   x + y
 """
 
-  let goodBindingWithAndKeywordTest = """
+  let goodBindingWithAndKeywordTest =
+    """
 let fn () =
   let x = 1
   let y = 2
@@ -31,7 +34,8 @@ let fn () =
 and good = ()
 """
 
-  let badBindingWithAndKeywordTest = """
+  let badBindingWithAndKeywordTest =
+    """
 let fn () =
   let x = 1
   let y = 2

--- a/src/FSLint.Tests/FunctionCallTest.fs
+++ b/src/FSLint.Tests/FunctionCallTest.fs
@@ -7,23 +7,32 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type FunctionCallTests() =
 
-  let goodNonCurriedFuncTest = """Func(p1, p2, p3)"""
+  let goodNonCurriedFuncTest =
+    """Func(p1, p2, p3)"""
 
-  let badNonCurriedFuncBracketSpacingTest = """Func( p1, p2, p3 )"""
+  let badNonCurriedFuncBracketSpacingTest =
+    """Func( p1, p2, p3 )"""
 
-  let badNonCurriedFuncSpacingTest = """Func (p1, p2, p3)"""
+  let badNonCurriedFuncSpacingTest =
+    """Func (p1, p2, p3)"""
 
-  let goodCurriedFuncPascalCaseTest = """str.Replace()"""
+  let goodCurriedFuncPascalCaseTest =
+    """str.Replace()"""
 
-  let badCurriedFuncPascalCaseTest = """str.Replace ()"""
+  let badCurriedFuncPascalCaseTest =
+    """str.Replace ()"""
 
-  let goodCurriedFuncLowerCaseTest = """str.replace ()"""
+  let goodCurriedFuncLowerCaseTest =
+    """str.replace ()"""
 
-  let badCurriedFuncLowerCaseTest = """str.replace()"""
+  let badCurriedFuncLowerCaseTest =
+    """str.replace()"""
 
-  let goodCurriedFuncPascalCaseNestedTest = """str.Substring(1).TrimStart()"""
+  let goodCurriedFuncPascalCaseNestedTest =
+    """str.Substring(1).TrimStart()"""
 
-  let badCurriedFuncPascalCaseNestedTest = """str.Substring(1).TrimStart ()"""
+  let badCurriedFuncPascalCaseNestedTest =
+    """str.Substring(1).TrimStart ()"""
 
   [<TestMethod>]
   member _.``[FunctionCall] Non Curried Function Bracket Spacing Test``() =

--- a/src/FSLint.Tests/IdentifierTests.fs
+++ b/src/FSLint.Tests/IdentifierTests.fs
@@ -6,43 +6,53 @@ open B2R2.FSLint.Program
 
 [<TestClass>]
 type IdentifierTests() =
-  let goodBindingLowercaseTest = """
+  let goodBindingLowercaseTest =
+    """
 let age = 30
 """
 
-  let badBindingLowercaseTest = """
+  let badBindingLowercaseTest =
+    """
 let Age = 30
 """
 
-  let goodBindingPascalCaseTest = """
+  let goodBindingPascalCaseTest =
+    """
 let [<Literal>] Age = 30
 """
 
-  let badBindingPascalCaseTest = """
+  let badBindingPascalCaseTest =
+    """
 let [<Literal>] age = 30
 """
 
-  let goodRecordDefPascalCaseTest = """
+  let goodRecordDefPascalCaseTest =
+    """
 type Person = { Age: int }
 """
 
-  let badRecordDefPascalCaseTest = """
+  let badRecordDefPascalCaseTest =
+    """
 type person = { Age: int }
 """
 
-  let goodRecordFieldNamePascalCaseTest = """
+  let goodRecordFieldNamePascalCaseTest =
+    """
 type Person = { Age: int }
 """
 
-  let badRecordFieldNamePascalCaseTest = """
+  let badRecordFieldNamePascalCaseTest =
+    """
 type Person = { age: int }
 """
 
-  let goodBindingUnderscoreTest = """
+  let goodBindingUnderscoreTest =
+    """
 let _age = 30
 """
 
-  let badBindingUnderscoreTest = """
+  let badBindingUnderscoreTest =
+    """
 let age_ = 30
 """
 

--- a/src/FSLint.Tests/IndexedPropertyTests.fs
+++ b/src/FSLint.Tests/IndexedPropertyTests.fs
@@ -7,15 +7,20 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type IndexedPropertyTests() =
 
-  let goodIndexedPropertyTest = """src[1]"""
+  let goodIndexedPropertyTest =
+    """src[1]"""
 
-  let badIndexedPropertySpacingFromAppTest = """src [1]"""
+  let badIndexedPropertySpacingFromAppTest =
+    """src [1]"""
 
-  let badIndexedPropertyBracketSpacingTest = """src[ 1 ]"""
+  let badIndexedPropertyBracketSpacingTest =
+    """src[ 1 ]"""
 
-  let goodIndexedPropertyHasOpmTest = """src[expr1..opm..expr2]"""
+  let goodIndexedPropertyHasOpmTest =
+    """src[expr1..opm..expr2]"""
 
-  let badIndexedPropertyHasOpmTest = """src[expr1 .. opm .. expr2]"""
+  let badIndexedPropertyHasOpmTest =
+    """src[expr1 .. opm .. expr2]"""
 
   [<TestMethod>]
   member _.``[IndexedProperty] Indexed Property Spacing From App Test``() =

--- a/src/FSLint.Tests/LineTests.fs
+++ b/src/FSLint.Tests/LineTests.fs
@@ -19,7 +19,7 @@ let x = {goodOnes}
 let x = {badOnes}
 """
 
-  let goodTrailingWhiteSpaceTest = """
+  let goodTrailingWhiteSpaceTest = $"""
 type A() =
   member _.X = 42
 """

--- a/src/FSLint.Tests/ParenTests.fs
+++ b/src/FSLint.Tests/ParenTests.fs
@@ -7,13 +7,17 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ParenTests() =
 
-  let goodEmptyTest = """()"""
+  let goodEmptyTest =
+    """()"""
 
-  let badEmptyTest = """( )"""
+  let badEmptyTest =
+    """( )"""
 
-  let goodBracketSpacingTest = """(1, 2)"""
+  let goodBracketSpacingTest =
+    """(1, 2)"""
 
-  let badBracketSpacingTest = """( 1, 2 )"""
+  let badBracketSpacingTest =
+    """( 1, 2 )"""
 
   [<TestMethod>]
   member _.``[Paren] Paren Empty Test``() =

--- a/src/FSLint.Tests/PatternMatchingTests.fs
+++ b/src/FSLint.Tests/PatternMatchingTests.fs
@@ -7,70 +7,82 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type PatternMatchingTests() =
 
-  let goodPatternBracketSpacingTest = """
+  let goodPatternBracketSpacingTest =
+    """
 match good with
 | [ 1; 2; 3 ] -> 1
 | _ -> 2
 """
 
-  let badPatternBracketSpacingTest = """
+  let badPatternBracketSpacingTest =
+    """
 match bad with
 | [1; 2; 3] -> 1
 | _ -> 2
 """
 
-  let badPatternElementSpacingTest = """
+  let badPatternElementSpacingTest =
+    """
 match bad with
 | [1; 2;3 ] -> 1
 | _ -> 2
 """
 
-  let goodPatternConsOperatorTest = """
+  let goodPatternConsOperatorTest =
+    """
 match good with
 | x :: xs -> 1
 | _ -> 2
 """
 
-  let badPatternConsOperatorTest = """
+  let badPatternConsOperatorTest =
+    """
 match bad with
 | x ::xs -> 1
 | _ -> 2
 """
 
-  let goodBarAndPatternIsInlineTest = """
+  let goodBarAndPatternIsInlineTest =
+    """
 match x with
 | Foo -> Some good
 | Bar -> None
 """
 
-  let badBarAndPatternIsInlineTest = """
+  let badBarAndPatternIsInlineTest =
+    """
 match x with
 | Foo |
   Bar -> Some bad
 """
 
-  let badBarAndMatchNotSameColTest = """
+  let badBarAndMatchNotSameColTest =
+    """
 match x with
   | Foo
   | Bar -> Some good
 """
 
-  let goodBarAndPatternSpacingTest = """
+  let goodBarAndPatternSpacingTest =
+    """
 match x with
 | Foo | Bar -> Some good
 """
 
-  let badBarAndPatternSpacingTest = """
+  let badBarAndPatternSpacingTest =
+    """
 match x with
 | Foo |Bar -> Some good
 """
 
-  let badArrowSpacingTest = """
+  let badArrowSpacingTest =
+    """
 match x with
 | Foo | Bar-> Some good
 """
 
-  let badArrowSpacingWithWhenTest = """
+  let badArrowSpacingWithWhenTest =
+    """
 match x with
 | Foo | Bar when cond-> Some good
 """

--- a/src/FSLint.Tests/RecordTests.fs
+++ b/src/FSLint.Tests/RecordTests.fs
@@ -7,7 +7,8 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type RecordTests() =
 
-  let goodBracketPositionTest = """
+  let goodBracketPositionTest =
+    """
 type InsSize =
   { MemSize: MemorySize
     RegSize: RegType
@@ -15,7 +16,8 @@ type InsSize =
     SizeCond: OperandsSizeCondition }
 """
 
-  let badBracketPositionTest = """
+  let badBracketPositionTest =
+    """
 type InsSize =
   {
     MemSize: MemorySize
@@ -25,7 +27,8 @@ type InsSize =
   }
 """
 
-  let badBracketPositionWithEqualTest = """
+  let badBracketPositionWithEqualTest =
+    """
 type InsSize = {
   MemSize: MemorySize
   RegSize: RegType
@@ -34,7 +37,8 @@ type InsSize = {
   }
 """
 
-  let badFieldTypeSpacingTest = """
+  let badFieldTypeSpacingTest =
+    """
 type InsSize =
   { MemSize:  MemorySize
     RegSize:  RegType
@@ -42,27 +46,32 @@ type InsSize =
     SizeCond:  OperandsSizeCondition }
 """
 
-  let goodBracketSpacingTest = """
+  let goodBracketSpacingTest =
+    """
 { Prefixes = prefs }
 """
 
-  let badBracketSpacingTest = """
+  let badBracketSpacingTest =
+    """
 {Prefixes = prefs}
 """
 
-  let goodBracketSpacingMultiLineTest = """
+  let goodBracketSpacingMultiLineTest =
+    """
 { Prefixes = prefs
   Opcode = opcode }
 """
 
-  let badBracketSpacingMultiLineTest = """
+  let badBracketSpacingMultiLineTest =
+    """
 {
   Prefixes = prefs
   Opcode = opcode
 }
 """
 
-  let badOperatorSpacingTest = """
+  let badOperatorSpacingTest =
+    """
 { field =value }
 """
 

--- a/src/FSLint.Tests/TupleTests.fs
+++ b/src/FSLint.Tests/TupleTests.fs
@@ -7,11 +7,14 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TupleTests() =
 
-  let goodCommaSpacingTest = """[ 1, 2, 3 ]"""
+  let goodCommaSpacingTest =
+    """[ 1, 2, 3 ]"""
 
-  let badSpacingAfterCommaTest = """[ 1,2, 3 ]"""
+  let badSpacingAfterCommaTest =
+    """[ 1,2, 3 ]"""
 
-  let badSpacingBeforeCommaTest = """[ 1 , 2, 3 ]"""
+  let badSpacingBeforeCommaTest =
+    """[ 1 , 2, 3 ]"""
 
   [<TestMethod>]
   member _.``[Tuple] Comma Spacing Test``() =

--- a/src/FSLint.Tests/TypeAnnotationTests.fs
+++ b/src/FSLint.Tests/TypeAnnotationTests.fs
@@ -6,99 +6,123 @@ open B2R2.FSLint.Program
 
 [<TestClass>]
 type TypeAnnotationTest() =
-  let goodEmptyParenTest = """
+  let goodEmptyParenTest =
+    """
 let fn () = ()
 """
 
-  let badEmptyParenTest = """
+  let badEmptyParenTest =
+    """
 let fn ( ) = ()
 """
 
-  let goodTypeAnnotationIntArrayTest = """
+  let goodTypeAnnotationIntArrayTest =
+    """
 let fn (param: int[]) = 10
 """
 
-  let badTypeAnnotationIntArrayTest = """
+  let badTypeAnnotationIntArrayTest =
+    """
 let fn (param: int []) = 10
 """
 
-  let goodTypeAnnotationIntTest = """
+  let goodTypeAnnotationIntTest =
+    """
 let fn (p: int) = 10
 """
 
-  let badTypeAnnotationIntTest = """
+  let badTypeAnnotationIntTest =
+    """
 let fn (p:int) = 10
 """
 
-  let goodTypeAnnotationStringTest = """
+  let goodTypeAnnotationStringTest =
+    """
 let fn (str: string) = "10"
 """
 
-  let badTypeAnnotationStringTest = """
+  let badTypeAnnotationStringTest =
+    """
 let fn (str:string) = "10"
 """
 
-  let goodTypeAnnotationStringSpaceTest = """
+  let goodTypeAnnotationStringSpaceTest =
+    """
 let fn (str: string) = "10"
 """
 
-  let badTypeAnnotationStringSpaceTest = """
+  let badTypeAnnotationStringSpaceTest =
+    """
 let fn (str :string) = "10"
 """
 
-  let goodTypeAnnotationArrayTest = """
+  let goodTypeAnnotationArrayTest =
+    """
 let inline toString (stmts: LowUIR.Stmt[]) = ()
 """
 
-  let badTypeAnnotationArrayTest = """
+  let badTypeAnnotationArrayTest =
+    """
 let inline toString (stmts:  LowUIR.Stmt[]) = ()
 """
 
-  let goodTypeAnnotationColonSpacingTest = """
+  let goodTypeAnnotationColonSpacingTest =
+    """
 type X = X of a: int * b: int
 """
 
-  let badTypeAnnotationColonSpacingTest = """
+  let badTypeAnnotationColonSpacingTest =
+    """
 type X = X of a : int * b: int
 """
 
-  let goodTypeAnnotationStarSpacingTest = """
+  let goodTypeAnnotationStarSpacingTest =
+    """
 type X = X of a: int * b: int
 """
 
-  let badTypeAnnotationStarSpacingTest = """
+  let badTypeAnnotationStarSpacingTest =
+    """
 type X = X of a : int* b: int
 """
 
-  let goodTypeAnnotationArraySpacingTest = """
+  let goodTypeAnnotationArraySpacingTest =
+    """
 type X = X of a: int[]
 """
 
-  let badTypeAnnotationArraySpacingTest = """
+  let badTypeAnnotationArraySpacingTest =
+    """
 type X = X of a: int []
 """
 
-  let goodParamArrayTest = """
+  let goodParamArrayTest =
+    """
 let x (x: int[]) = x
 """
 
-  let badParamArrayTest = """
+  let badParamArrayTest =
+    """
 let x (x: int []) = x
 """
 
-  let goodTupleArrayTest = """
+  let goodTupleArrayTest =
+    """
 let x (x: int[] * int) = x
 """
 
-  let badTupleArrayTest = """
+  let badTupleArrayTest =
+    """
 let x (x: int[] * int []) = x
 """
 
-  let goodArrowSpacingTest = """
+  let goodArrowSpacingTest =
+    """
 let fn (x: list<int> -> string[] * string) = x
 """
 
-  let badArrowSpacingTest = """
+  let badArrowSpacingTest =
+    """
 let fn (x: list<int>->string[] * string) = x
 """
 

--- a/src/FSLint.Tests/TypeCastTests.fs
+++ b/src/FSLint.Tests/TypeCastTests.fs
@@ -7,13 +7,17 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeCastTests() =
 
-  let goodUpcastSpacingTest = """source :> target"""
+  let goodUpcastSpacingTest =
+    """source :> target"""
 
-  let badUpcastSpacingTest = """source:>target"""
+  let badUpcastSpacingTest =
+    """source:>target"""
 
-  let goodDowncastSpacingTest = """source :?> target"""
+  let goodDowncastSpacingTest =
+    """source :?> target"""
 
-  let badDowncastSpacingTest = """source:?>target"""
+  let badDowncastSpacingTest =
+    """source:?>target"""
 
   [<TestMethod>]
   member _.``[TypeCast] Upcast Spacing Test``() =

--- a/src/FSLint.Tests/TypeConstructorTests.fs
+++ b/src/FSLint.Tests/TypeConstructorTests.fs
@@ -7,9 +7,11 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeConstructorTests() =
 
-  let goodConstructorSpacingTest = """new TestClass(param1, param2)"""
+  let goodConstructorSpacingTest =
+    """new TestClass(param1, param2)"""
 
-  let badConstructorSpacingTest = """new TestClass (param1, param2)"""
+  let badConstructorSpacingTest =
+    """new TestClass (param1, param2)"""
 
   [<TestMethod>]
   member _.``[TypeConstructor] Between Infix and Paren Spacing Test``() =

--- a/src/FSLint.Tests/TypeUseTests.fs
+++ b/src/FSLint.Tests/TypeUseTests.fs
@@ -7,17 +7,23 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeUseTests() =
 
-  let goodGenericArguSpacingTest = """func<genericArgu>"""
+  let goodGenericArguSpacingTest =
+    """func<genericArgu>"""
 
-  let badGenericArguSpacingTest = """func <genericArgu>"""
+  let badGenericArguSpacingTest =
+    """func <genericArgu>"""
 
-  let goodGenericArguCommaTest = """func<type1, type2>"""
+  let goodGenericArguCommaTest =
+    """func<type1, type2>"""
 
-  let badGenericArguCommaTest = """func<type1,type2>"""
+  let badGenericArguCommaTest =
+    """func<type1,type2>"""
 
-  let goodGenericArguStarTest = """func<type1 * type2>"""
+  let goodGenericArguStarTest =
+    """func<type1 * type2>"""
 
-  let badGenericArguStarTest = """func<type1*type2>"""
+  let badGenericArguStarTest =
+    """func<type1*type2>"""
 
   [<TestMethod>]
   member _.``[TypeUse] Generic Argument Spacing Test``() =

--- a/src/FSLint/ArrayOrListConvention.fs
+++ b/src/FSLint/ArrayOrListConvention.fs
@@ -218,6 +218,8 @@ let rec checkSingleLine src = function
   | SynExpr.YieldOrReturn _
   | SynExpr.YieldOrReturnFrom _
   | SynExpr.Upcast _
+  | SynExpr.ArrayOrList _
+  | SynExpr.ArrayOrListComputed _
   | SynExpr.InterpolatedString _
   | SynExpr.IfThenElse _
   | SynExpr.Record _

--- a/src/FSLint/DeclarationConvention.fs
+++ b/src/FSLint/DeclarationConvention.fs
@@ -97,19 +97,24 @@ let checkEqualSpacing (src: ISourceText) (range: range option) =
   else
     ()
 
+let isTripleQuoteString = function
+  | SynExpr.Const(SynConst.String(synStringKind = SynStringKind.TripleQuote), _)
+    -> true
+  | _
+    -> false
+
 let checkLetAndMultilineRhsPlacement (src: ISourceText) (binding: SynBinding) =
   let SynBinding(expr = body; trivia = trivia) = binding
   match trivia.EqualsRange with
   | Some eqRange ->
     match body with
-    | SynExpr.Const(SynConst.String(_, kind, _), _) when kind = SynStringKind.TripleQuote ->
-      if eqRange.StartLine = body.Range.StartLine then
-        reportError src body.Range
-          "Triple-quoted string must start on the next line after '='."
-      else ()
-    | _ -> ()
+    | _
+     when isTripleQuoteString body && eqRange.StartLine = body.Range.StartLine
+      -> reportError src body.Range "Triple-quoted should be on the next line."
+    | _
+      -> ()
   | None -> ()
- 
+
 let check (src: ISourceText) decls =
   decls
   |> List.pairwise

--- a/src/FSLint/FunctionCallConvention.fs
+++ b/src/FSLint/FunctionCallConvention.fs
@@ -162,20 +162,14 @@ let rec checkMethodParenSpacing (src: ISourceText) (expr: SynExpr) =
     exprs |> List.iter (checkMethodParenSpacing src)
   | _ -> ()
 
-let checkDotGetSpacing (src: ISourceText) (expr: SynExpr) (dotRange: range) (longDotId: SynLongIdent) =
+let checkDotGetSpacing src (expr: SynExpr) (dotRange: range) longDotId =
   if expr.Range.EndLine = dotRange.StartLine
     && expr.Range.EndColumn <> dotRange.StartColumn
-  then 
-    reportError src dotRange "Unexpected space before '.' in member access"
+  then reportError src dotRange "Unexpected space before '.' in member access"
   else ()
-  
-  let (SynLongIdent(id = ids)) = longDotId
-  match ids with
-  | firstId :: _ -> 
-    if dotRange.EndLine = firstId.idRange.StartLine then
-      if dotRange.EndColumn <> firstId.idRange.StartColumn then
-        reportError src dotRange "Unexpected space after '.' in member access"
-      else ()
+  match longDotId with
+  | SynLongIdent(id = id) ->
+    if dotRange.EndLine = id[0].idRange.StartLine
+      && dotRange.EndColumn <> id[0].idRange.StartColumn
+    then reportError src dotRange "Unexpected space after '.' in member access"
     else ()
-  | [] -> 
-    ()

--- a/src/FSLint/Program.fs
+++ b/src/FSLint/Program.fs
@@ -458,21 +458,25 @@ let getFsFiles (root: string) =
        Regex $"obj{sep}Release{sep}"
        Regex $"CFG.Tests" |]
   Directory.EnumerateFiles(root, "*.fs", SearchOption.AllDirectories)
-  |> Seq.filter (fun f -> not (exclusion |> Array.exists (fun r -> r.IsMatch f)))
+  |> Seq.filter
+    (fun f -> not (exclusion |> Array.exists (fun r -> r.IsMatch f)))
   |> Seq.sort
   |> Seq.toArray
 
 /// Collects .fsproj and .sln project/solution files
 let getProjOrSlnFiles (root: string) =
   seq {
-    yield! Directory.EnumerateFiles(root, "*.fsproj", SearchOption.AllDirectories)
-    yield! Directory.EnumerateFiles(root, "*.sln", SearchOption.AllDirectories)
+    yield!
+      Directory.EnumerateFiles(root, "*.fsproj", SearchOption.AllDirectories)
+    yield!
+      Directory.EnumerateFiles(root, "*.sln", SearchOption.AllDirectories)
   }
   |> Seq.sort
   |> Seq.toArray
 
 /// Lints a single file, catching exceptions and returning a `LintOutcome`.
-let tryLintToBuffer (linter: ILintable) (index: int) (path: string) : LintOutcome =
+let tryLintToBuffer
+  (linter: ILintable) (index: int) (path: string): LintOutcome =
   let sb = StringBuilder()
   let append (s: string) = sb.AppendLine(s) |> ignore
   try
@@ -498,7 +502,6 @@ let runParallelPreservingOrder (linter: ILintable) (paths: string array) =
     |> Async.Parallel
     |> Async.RunSynchronously
     |> Array.sortBy (fun r -> r.Index)
-
   results |> Array.exists (fun r -> not r.Ok)
 
 [<EntryPoint>]


### PR DESCRIPTION
Triple outlet must not be in same line with let statement

Before Fix:
- let a = """  
   
After Fix:
- let a =
""" 

I'm still testing DotGet Spacing Check for its different Parsing style