### PR TITLE
Add LineBreak Rule && Fix TripleQuote Rule

### DIFF
--- a/src/FSLint.Tests/AppTests.fs
+++ b/src/FSLint.Tests/AppTests.fs
@@ -37,11 +37,9 @@ good[1..]
 bad[ 1.. ]
 """
 
-  let goodListSpaceFunAppTest =
-    """[ fn 1 2 3 x ]"""
+  let goodListSpaceFunAppTest = """[ fn 1 2 3 x ]"""
 
-  let badListSpaceFunAppTest =
-    """[ fn  1 2 3 x ]"""
+  let badListSpaceFunAppTest = """[ fn  1 2 3 x ]"""
 
   [<TestMethod>]
   member _.``[App] List Space Before and After Infix Test``() =

--- a/src/FSLint.Tests/ArgumentAssignmentTests.fs
+++ b/src/FSLint.Tests/ArgumentAssignmentTests.fs
@@ -7,11 +7,9 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type AssignmentTests() =
 
-  let goodNamedArgumentSpacingTest =
-    """func (param = value)"""
+  let goodNamedArgumentSpacingTest = """func (param = value)"""
 
-  let badNamedArgumentSpacingTest =
-    """func (param=value)"""
+  let badNamedArgumentSpacingTest = """func (param=value)"""
 
 
   [<TestMethod>]

--- a/src/FSLint.Tests/ArrayOrListTests.fs
+++ b/src/FSLint.Tests/ArrayOrListTests.fs
@@ -9,59 +9,41 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ArrayOrListTests() =
 
-  let goodEmptyTest =
-    """[]"""
+  let goodEmptyTest = """[]"""
 
-  let badEmptyTest =
-    """[ ]"""
+  let badEmptyTest = """[ ]"""
 
-  let goodArrayEmptyTest =
-    """[||]"""
+  let goodArrayEmptyTest = """[||]"""
 
-  let badArrayEmptyTest =
-    """[| |]"""
+  let badArrayEmptyTest = """[| |]"""
 
-  let goodBracketSpacingTest =
-    """[ 1; 2; 3; 4 ]"""
+  let goodBracketSpacingTest = """[ 1; 2; 3; 4 ]"""
 
-  let badBracketSpacingTest =
-    """[1; 2; 3; 4]"""
+  let badBracketSpacingTest = """[1; 2; 3; 4]"""
 
-  let goodArrayBracketSpacingTest =
-    """[| 1; 2; 3; 4 |]"""
+  let goodArrayBracketSpacingTest = """[| 1; 2; 3; 4 |]"""
 
-  let badArrayBracketSpacingTest =
-    """[|1; 2; 3; 4|]"""
+  let badArrayBracketSpacingTest = """[|1; 2; 3; 4|]"""
 
-  let goodElementSpacingTest =
-    """[ 1; 2 ]"""
+  let goodElementSpacingTest = """[ 1; 2 ]"""
 
-  let badNoWhitespaceBetweenElementsTest =
-    """[ 1;2 ]"""
+  let badNoWhitespaceBetweenElementsTest = """[ 1;2 ]"""
 
-  let badTooMuchWhitespaceBetweenElementsTest =
-    """[ 1;  2 ]"""
+  let badTooMuchWhitespaceBetweenElementsTest = """[ 1;  2 ]"""
 
-  let badWhitespaceBeforeSeparatorTest =
-    """[ 1 ;2 ]"""
+  let badWhitespaceBeforeSeparatorTest = """[ 1 ;2 ]"""
 
-  let goodRangeOperatorTest =
-    """[ 1 .. 10 ]"""
+  let goodRangeOperatorTest = """[ 1 .. 10 ]"""
 
-  let badRangeOperatorTest =
-    """[ 1..10 ]"""
+  let badRangeOperatorTest = """[ 1..10 ]"""
 
-  let goodRangeOperatorWithIdentTest =
-    """[ startIdent .. endIdent ]"""
+  let goodRangeOperatorWithIdentTest = """[ startIdent .. endIdent ]"""
 
-  let badRangeOperatorWithIdentTest =
-    """[ startIdent..endIdent ]"""
+  let badRangeOperatorWithIdentTest = """[ startIdent..endIdent ]"""
 
-  let goodRangeOperatorWithStepTest =
-    """[ 1 .. 2 .. 10 ]"""
+  let goodRangeOperatorWithStepTest = """[ 1 .. 2 .. 10 ]"""
 
-  let badRangeOperatorWithStepTest =
-    """[ 1 ..2.. 10 ]"""
+  let badRangeOperatorWithStepTest = """[ 1 ..2.. 10 ]"""
 
   let goodRangeOperatorWithStepAndIdentTest =
     """

--- a/src/FSLint.Tests/DeclarationTests.fs
+++ b/src/FSLint.Tests/DeclarationTests.fs
@@ -40,3 +40,63 @@ let bar = 2
     Assert.ThrowsException<LintException>(fun () ->
       linterForFs.Lint(Constants.FakeFsPath, badTopBindingTooMuchSpacingTest)
      ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Single line fits in 80 columns``() =
+    let code =
+      """
+let func = printfn "hello"
+"""
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Short function on one line``() =
+    let code =
+      """
+let add x y = x + y
+"""
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Multi-line with long body - allowed``() =
+    let code =
+      """
+let processData input =
+  let step1 = transform input
+  let step2 = validate step1
+  compute step2
+"""
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - unnecessary line break``() =
+    let code =
+      """
+let func =
+  printfn "hello"
+"""
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - short function unnecessarily split``() =
+    let code =
+      """
+let add x y =
+  x + y
+"""
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - simple value unnecessarily split``() =
+    let code =
+      """
+let value =
+  42
+"""
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore

--- a/src/FSLint.Tests/FunctionCallTest.fs
+++ b/src/FSLint.Tests/FunctionCallTest.fs
@@ -7,32 +7,23 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type FunctionCallTests() =
 
-  let goodNonCurriedFuncTest =
-    """Func(p1, p2, p3)"""
+  let goodNonCurriedFuncTest = """Func(p1, p2, p3)"""
 
-  let badNonCurriedFuncBracketSpacingTest =
-    """Func( p1, p2, p3 )"""
+  let badNonCurriedFuncBracketSpacingTest = """Func( p1, p2, p3 )"""
 
-  let badNonCurriedFuncSpacingTest =
-    """Func (p1, p2, p3)"""
+  let badNonCurriedFuncSpacingTest = """Func (p1, p2, p3)"""
 
-  let goodCurriedFuncPascalCaseTest =
-    """str.Replace()"""
+  let goodCurriedFuncPascalCaseTest = """str.Replace()"""
 
-  let badCurriedFuncPascalCaseTest =
-    """str.Replace ()"""
+  let badCurriedFuncPascalCaseTest = """str.Replace ()"""
 
-  let goodCurriedFuncLowerCaseTest =
-    """str.replace ()"""
+  let goodCurriedFuncLowerCaseTest = """str.replace ()"""
 
-  let badCurriedFuncLowerCaseTest =
-    """str.replace()"""
+  let badCurriedFuncLowerCaseTest = """str.replace()"""
 
-  let goodCurriedFuncPascalCaseNestedTest =
-    """str.Substring(1).TrimStart()"""
+  let goodCurriedFuncPascalCaseNestedTest = """str.Substring(1).TrimStart()"""
 
-  let badCurriedFuncPascalCaseNestedTest =
-    """str.Substring(1).TrimStart ()"""
+  let badCurriedFuncPascalCaseNestedTest = """str.Substring(1).TrimStart ()"""
 
   [<TestMethod>]
   member _.``[FunctionCall] Non Curried Function Bracket Spacing Test``() =

--- a/src/FSLint.Tests/IndexedPropertyTests.fs
+++ b/src/FSLint.Tests/IndexedPropertyTests.fs
@@ -7,20 +7,15 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type IndexedPropertyTests() =
 
-  let goodIndexedPropertyTest =
-    """src[1]"""
+  let goodIndexedPropertyTest = """src[1]"""
 
-  let badIndexedPropertySpacingFromAppTest =
-    """src [1]"""
+  let badIndexedPropertySpacingFromAppTest = """src [1]"""
 
-  let badIndexedPropertyBracketSpacingTest =
-    """src[ 1 ]"""
+  let badIndexedPropertyBracketSpacingTest = """src[ 1 ]"""
 
-  let goodIndexedPropertyHasOpmTest =
-    """src[expr1..opm..expr2]"""
+  let goodIndexedPropertyHasOpmTest = """src[expr1..opm..expr2]"""
 
-  let badIndexedPropertyHasOpmTest =
-    """src[expr1 .. opm .. expr2]"""
+  let badIndexedPropertyHasOpmTest = """src[expr1 .. opm .. expr2]"""
 
   [<TestMethod>]
   member _.``[IndexedProperty] Indexed Property Spacing From App Test``() =

--- a/src/FSLint.Tests/ParenTests.fs
+++ b/src/FSLint.Tests/ParenTests.fs
@@ -7,17 +7,13 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type ParenTests() =
 
-  let goodEmptyTest =
-    """()"""
+  let goodEmptyTest = """()"""
 
-  let badEmptyTest =
-    """( )"""
+  let badEmptyTest = """( )"""
 
-  let goodBracketSpacingTest =
-    """(1, 2)"""
+  let goodBracketSpacingTest = """(1, 2)"""
 
-  let badBracketSpacingTest =
-    """( 1, 2 )"""
+  let badBracketSpacingTest = """( 1, 2 )"""
 
   [<TestMethod>]
   member _.``[Paren] Paren Empty Test``() =

--- a/src/FSLint.Tests/TupleTests.fs
+++ b/src/FSLint.Tests/TupleTests.fs
@@ -7,14 +7,11 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TupleTests() =
 
-  let goodCommaSpacingTest =
-    """[ 1, 2, 3 ]"""
+  let goodCommaSpacingTest = """[ 1, 2, 3 ]"""
 
-  let badSpacingAfterCommaTest =
-    """[ 1,2, 3 ]"""
+  let badSpacingAfterCommaTest = """[ 1,2, 3 ]"""
 
-  let badSpacingBeforeCommaTest =
-    """[ 1 , 2, 3 ]"""
+  let badSpacingBeforeCommaTest = """[ 1 , 2, 3 ]"""
 
   [<TestMethod>]
   member _.``[Tuple] Comma Spacing Test``() =

--- a/src/FSLint.Tests/TypeCastTests.fs
+++ b/src/FSLint.Tests/TypeCastTests.fs
@@ -7,17 +7,13 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeCastTests() =
 
-  let goodUpcastSpacingTest =
-    """source :> target"""
+  let goodUpcastSpacingTest = """source :> target"""
 
-  let badUpcastSpacingTest =
-    """source:>target"""
+  let badUpcastSpacingTest = """source:>target"""
 
-  let goodDowncastSpacingTest =
-    """source :?> target"""
+  let goodDowncastSpacingTest = """source :?> target"""
 
-  let badDowncastSpacingTest =
-    """source:?>target"""
+  let badDowncastSpacingTest = """source:?>target"""
 
   [<TestMethod>]
   member _.``[TypeCast] Upcast Spacing Test``() =

--- a/src/FSLint.Tests/TypeConstructorTests.fs
+++ b/src/FSLint.Tests/TypeConstructorTests.fs
@@ -7,11 +7,9 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeConstructorTests() =
 
-  let goodConstructorSpacingTest =
-    """new TestClass(param1, param2)"""
+  let goodConstructorSpacingTest = """new TestClass(param1, param2)"""
 
-  let badConstructorSpacingTest =
-    """new TestClass (param1, param2)"""
+  let badConstructorSpacingTest = """new TestClass (param1, param2)"""
 
   [<TestMethod>]
   member _.``[TypeConstructor] Between Infix and Paren Spacing Test``() =

--- a/src/FSLint.Tests/TypeUseTests.fs
+++ b/src/FSLint.Tests/TypeUseTests.fs
@@ -7,23 +7,17 @@ open B2R2.FSLint.Program
 [<TestClass>]
 type TypeUseTests() =
 
-  let goodGenericArguSpacingTest =
-    """func<genericArgu>"""
+  let goodGenericArguSpacingTest = """func<genericArgu>"""
 
-  let badGenericArguSpacingTest =
-    """func <genericArgu>"""
+  let badGenericArguSpacingTest = """func <genericArgu>"""
 
-  let goodGenericArguCommaTest =
-    """func<type1, type2>"""
+  let goodGenericArguCommaTest = """func<type1, type2>"""
 
-  let badGenericArguCommaTest =
-    """func<type1,type2>"""
+  let badGenericArguCommaTest = """func<type1,type2>"""
 
-  let goodGenericArguStarTest =
-    """func<type1 * type2>"""
+  let goodGenericArguStarTest = """func<type1 * type2>"""
 
-  let badGenericArguStarTest =
-    """func<type1*type2>"""
+  let badGenericArguStarTest = """func<type1*type2>"""
 
   [<TestMethod>]
   member _.``[TypeUse] Generic Argument Spacing Test``() =

--- a/src/FSLint/FunctionBodyConvention.fs
+++ b/src/FSLint/FunctionBodyConvention.fs
@@ -24,8 +24,7 @@ let private countTripleQuotes (line: string) =
 let private isInsideStringLiteral (src: ISourceText) (range: range) lineIdx =
   let lines =
     [ range.StartLine - 1 .. lineIdx ] |> List.map (src.GetLineString)
-  let totalTripleQuotes =
-    lines |> List.sumBy countTripleQuotes
+  let totalTripleQuotes = lines |> List.sumBy countTripleQuotes
   totalTripleQuotes % 2 = 1
 
 let checkNested (src: ISourceText) range lineNums =

--- a/src/FSLint/IdentifierConvention.fs
+++ b/src/FSLint/IdentifierConvention.fs
@@ -7,8 +7,7 @@ type CaseStyle =
   | LowerCamelCase
   | PascalCase
 
-let private keywords =
-  [| "new" |]
+let private keywords = [| "new" |]
 
 let private isKnownKeyWord (identifier: string) =
   Array.exists (fun kw -> kw = identifier) keywords

--- a/src/FSLint/Program.fs
+++ b/src/FSLint/Program.fs
@@ -362,6 +362,7 @@ and checkBinding src case binding =
   checkPattern src case false trivia pat
   DeclarationConvention.checkEqualSpacing src trivia.EqualsRange
   DeclarationConvention.checkLetAndMultilineRhsPlacement src binding
+  DeclarationConvention.checkUnnecessaryLineBreak src binding
   TypeUseConvention.checkParamTypeSpacing src pat
   TypeAnnotation.checkReturnInfo src pat returnInfo
   PatternMatchingConvention.checkBody src pat
@@ -482,6 +483,7 @@ let tryLintToBuffer
   try
     Console.WriteLine($"--- File: {path}")
     append $"Linting file: {path}"
+    Utils.setCurrentFile path
     let bytes = File.ReadAllBytes path |> ensureNoBOM
     let txt = System.Text.Encoding.UTF8.GetString bytes
     linter.Lint(path, txt)
@@ -508,11 +510,13 @@ let runParallelPreservingOrder (linter: ILintable) (paths: string array) =
 let main args =
   if args.Length < 1 then exitWithError "Usage: fslint <file|dir>"
   elif File.Exists args[0] then
+    Utils.setCurrentFile args[0]
     let outcome = tryLintToBuffer linterForFs 0 args[0]
     if outcome.Ok then 0 else 1
   elif Directory.Exists args[0] then
     let projOrSln = getProjOrSlnFiles args[0]
     for p in projOrSln do
+      Utils.setCurrentFile p
       let bytes = File.ReadAllBytes p |> ensureNoBOM
       let txt = System.Text.Encoding.UTF8.GetString bytes
       linterForProjSln.Lint(p, txt)

--- a/src/FSLint/Utils.fs
+++ b/src/FSLint/Utils.fs
@@ -8,19 +8,36 @@ open FSharp.Compiler.Text
 
 exception LintException of string
 
-let raiseWithError (message: string) =
-  raise <| LintException message
+let private outputLock = obj ()
+
+let private currentFilePath = new Threading.AsyncLocal<string>()
+
+let setCurrentFile (path: string) = currentFilePath.Value <- path
+
+let raiseWithError (message: string) = raise <| LintException message
 
 let exitWithError (message: string) =
   Console.WriteLine message
   exit 1
 
-let warn (message: string) =
-  Console.Error.WriteLine message
+let warn (message: string) = Console.Error.WriteLine message
 
 let reportError (src: ISourceText) (range: range) message =
-  Console.Error.WriteLine(src.GetLineString(range.StartLine - 1))
-  Console.Error.WriteLine(String.replicate range.StartColumn " " + "^")
+  lock outputLock (fun () ->
+    let fileName =
+      let path = currentFilePath.Value
+      if isNull path || String.IsNullOrEmpty(path) then ""
+      else Path.GetFileName(path)
+    if String.IsNullOrEmpty(fileName) then
+      Console.Error.WriteLine(sprintf "Line %d: %O" range.StartLine message)
+    else
+      Console.Error.WriteLine(
+        sprintf "[%s] Line %d: %O" fileName range.StartLine message)
+    Console.Error.WriteLine(
+      src.GetLineString(range.StartLine - 1))
+    Console.Error.WriteLine(
+      String.replicate range.StartColumn " " + "^")
+  )
   raiseWithError $"{range.StartLine} {message}"
 
 let runOnEveryFsFile (path: string) (action: string -> unit) =


### PR DESCRIPTION
## Declaration Line Break Convention

### Purpose
Detect and flag unnecessary line breaks in declarations that fit within 80 columns

### Rule
If `let` declaration from start to end fits within 80 columns (including indentation), it should be written on a single line

### Examples

#### ❌ Bad (Unnecessary line break)
```fsharp
let func =
  printfn "hello"

let add x y =
  x + y

let value =
  42
```

#### ✅ Good (Properly formatted)
```fsharp
let func = printfn "hello"
let add x y = x + y
let value = 42
```

## TripleQuote Convention Update

### Changes
- **Relaxed single-line triple-quote restriction**: Triple-quoted strings on the same line as `=` are now allowed if they start and end on the same line

### Before
```fsharp
❌ let m = """m"""  // Error: Triple-quoted should be on the next line
```

### After
```fsharp
✅ let m = """m"""  // Allowed: single-line triple quote
✅ let short = """hello world"""

❌ let m = """  // Still error: multi-line triple quote
multi
"""

✅ let m =  // Correct format for multi-line
  """
multi
"""
```

---