### PR TITLE
Add ComputationExpression Rule

### DIFF
--- a/src/FSLint.Tests/DeclarationTests.fs
+++ b/src/FSLint.Tests/DeclarationTests.fs
@@ -100,3 +100,71 @@ let value =
     Assert.ThrowsException<LintException>(fun () ->
       linterForFs.Lint(Constants.FakeFsPath, code)
     ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Computation expression on next line - good``() =
+    let code =
+      "let loop () =\n" +
+      "  async {\n" +
+      "    return 42\n" +
+      "  }\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Task expression on next line - good``() =
+    let code =
+      "let processData () =\n" +
+      "  task {\n" +
+      "    return! getData ()\n" +
+      "  }\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Seq expression on next line - good``() =
+    let code =
+      "let numbers =\n" +
+      "  seq {\n" +
+      "    yield 1\n" +
+      "    yield 2\n" +
+      "  }\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - async on same line as equals``() =
+    let code =
+      "let loop () = async {\n" +
+      "  return 42\n" +
+      "}\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - task on same line as equals``() =
+    let code =
+      "let process () = task {\n" +
+      "  return 1\n" +
+      "}\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Error - seq on same line as equals``() =
+    let code =
+      "let nums = seq {\n" +
+      "  yield 1\n" +
+      "}\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[Declaration] Rec function with async on next line - good``() =
+    let code =
+      "let rec loop () =\n" +
+      "  async {\n" +
+      "    do! Async.Sleep 100\n" +
+      "    return! loop ()\n" +
+      "  }\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)

--- a/src/FSLint/DeclarationConvention.fs
+++ b/src/FSLint/DeclarationConvention.fs
@@ -147,6 +147,20 @@ let checkUnnecessaryLineBreak (src: ISourceText) (binding: SynBinding) =
       else ()
     | None -> ()
 
+let isComputationExpr = function
+  | SynExpr.ComputationExpr _ -> true
+  | SynExpr.App(argExpr = SynExpr.ComputationExpr _) -> true
+  | _ -> false
+
+let checkComputationExprPlacement (src: ISourceText) (binding: SynBinding) =
+  let SynBinding(expr = body; trivia = trivia) = binding
+  match trivia.EqualsRange with
+  | Some eqRange ->
+    if isComputationExpr body && eqRange.EndLine = body.Range.StartLine then
+      reportError src body.Range
+        "Computation expression should start on the next line after '='"
+  | None -> ()
+
 let check (src: ISourceText) decls =
   decls
   |> List.pairwise

--- a/src/FSLint/Program.fs
+++ b/src/FSLint/Program.fs
@@ -363,6 +363,7 @@ and checkBinding src case binding =
   DeclarationConvention.checkEqualSpacing src trivia.EqualsRange
   DeclarationConvention.checkLetAndMultilineRhsPlacement src binding
   DeclarationConvention.checkUnnecessaryLineBreak src binding
+  DeclarationConvention.checkComputationExprPlacement src binding
   TypeUseConvention.checkParamTypeSpacing src pat
   TypeAnnotation.checkReturnInfo src pat returnInfo
   PatternMatchingConvention.checkBody src pat


### PR DESCRIPTION
## Computation Expression Formatting Convention

### Purpose
Enforce proper line break placement for computation expressions (async, task, etc.) in let bindings

### Rule
Computation expressions should start on a new line after `=`, not on the same line

### Examples

#### ❌ Bad (Computation expression on same line as `=`)
```fsharp
let rec loop () = async {
  // body
}

let processData () = task {
  // body
}

let compute x = seq {
  yield x
}
```

#### ✅ Good (Computation expression on next line)
```fsharp
let rec loop () =
  async {
    // body
  }

let processData () =
  task {
    // body
  }

let compute x =
  seq {
    yield x
  }
```