### PR TITLE
Add Class Declaration Order Rule

### DIFF
--- a/src/FSLint.Tests/B2R2.FSLint.Tests.fsproj
+++ b/src/FSLint.Tests/B2R2.FSLint.Tests.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="LineTests.fs" />
     <Compile Include="IdentifierTests.fs" />
     <Compile Include="ArgumentAssignmentTests.fs" />
+    <Compile Include="ClassMemberOrderTests.fs" />
     <Compile Include="TupleTests.fs" />
     <Compile Include="ParenTests.fs" />
     <Compile Include="TypeCastTests.fs" />

--- a/src/FSLint.Tests/ClassMemberOrderTests.fs
+++ b/src/FSLint.Tests/ClassMemberOrderTests.fs
@@ -1,0 +1,135 @@
+namespace B2R2.FSLint.Tests
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open B2R2.FSLint
+open B2R2.FSLint.Program
+
+[<TestClass>]
+type ClassMemberOrderTests() =
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Properties before methods - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Property = 42\n" +
+      "  member _.Method() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Static before instance - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  static member StaticMethod() = ()\n" +
+      "  member _.InstanceMethod() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Complete order - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  val mutable private _field: int\n" +
+      "\n" +
+      "  static member StaticProp = 10\n" +
+      "\n" +
+      "  member _.InstanceProp = 20\n" +
+      "\n" +
+      "  static member StaticMethod() = ()\n" +
+      "\n" +
+      "  member _.InstanceMethod() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Multiple properties then methods - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Prop1 = 1\n" +
+      "  member _.Prop2 = 2\n" +
+      "  member _.Prop3 = 3\n" +
+      "\n" +
+      "  member _.Method1() = ()\n" +
+      "  member _.Method2() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Auto-properties before methods - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member val AutoProp = 42 with get, set\n" +
+      "\n" +
+      "  member _.Method() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Error - method before property``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Method() = ()\n" +
+      "  member _.Property = 42\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Error - instance before static``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.InstanceMethod() = ()\n" +
+      "  static member StaticMethod() = ()\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Error - method before field``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Method() = ()\n" +
+      "  val mutable Field: int\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Error - static instance before static static``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.InstanceProp = 1\n" +
+      "  static member StaticProp = 2\n"
+    Assert.ThrowsException<LintException>(fun () ->
+      linterForFs.Lint(Constants.FakeFsPath, code)
+    ) |> ignore
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Interface implementation ignored - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Method() = ()\n" +
+      "\n" +
+      "  interface System.IDisposable with\n" +
+      "    member _.Dispose() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Abstract members - good``() =
+    let code =
+      "[<AbstractClass>]\n" +
+      "type MyClass() =\n" +
+      "  abstract member AbstractProp: int\n" +
+      "  abstract member AbstractMethod: unit -> unit\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Single member - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.OnlyMethod() = ()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)
+
+  [<TestMethod>]
+  member _.``[MemberOrder] Operators treated as methods - good``() =
+    let code =
+      "type MyClass() =\n" +
+      "  member _.Property = 42\n" +
+      "\n" +
+      "  static member (+) (a: MyClass, b: MyClass) = MyClass()\n"
+    linterForFs.Lint(Constants.FakeFsPath, code)

--- a/src/FSLint/Program.fs
+++ b/src/FSLint/Program.fs
@@ -319,6 +319,7 @@ and checkTypeDefnRepr src lid repr trivia =
   match repr with
   | SynTypeDefnRepr.ObjectModel(_, members, _) ->
     ClassDefinition.checkIdentifierWithParen src members
+    ClassMemberConvention.checkMemberOrder src members
     checkMemberDefns src members
   | SynTypeDefnRepr.Simple(repr, _) ->
     checkTypeDefnSimpleRepr src trivia repr


### PR DESCRIPTION
## Class Member Declaration Order Convention

### Purpose
Enforce consistent ordering of class members following C# StyleCop conventions (SA1201-SA1215) adapted for F#

### Rule
Class members should be ordered by:
1. **Member Type** (primary ordering)
2. **Access Modifier** (secondary ordering)
3. **Static vs Instance** (tertiary ordering)
4. **Readonly vs Mutable** (for fields only)

### Member Type Order
1. Constant Fields (`[<Literal>]`)
2. Fields (`val`)
3. Constructors (implicit and explicit)
4. Events
5. Properties (including auto-properties)
6. Indexers
7. Methods
8. Nested Types (structs, classes, interfaces)

### Access Modifier Order
1. `public` 
2. `internal`
3. `protected` 
4. `private`

### Static vs Instance Order
1. `static` members
2. Instance members

### Examples

#### ❌ Bad (Wrong order - method before property)
```fsharp
type MyClass() =
  member _.DoSomething() = ()        // Method first (wrong!)
  member _.MyProperty = 42           // Property second
  
type BadOrder() =
  member _.InstanceMethod() = ()     // Instance before static (wrong!)
  static member StaticMethod() = ()
```

#### ✅ Good (Correct order)
```fsharp
type MyClass() =
  // Properties first
  member _.MyProperty = 42
  member _.AnotherProperty = "test"
  
  // Methods second
  member _.DoSomething() = ()
  member _.DoMore() = ()

type GoodOrder() =
  // Static before instance
  static member StaticMethod() = ()
  static member AnotherStatic() = ()
  
  // Instance methods
  member _.InstanceMethod() = ()
  member _.AnotherInstance() = ()
```

#### ✅ Good (Complete example with all rules)
```fsharp
type CompleteExample() =
  // 1. Fields
  val mutable privateField: int
  
  // 2. Properties - static first
  static member StaticProperty = 10
  member _.PublicProperty = 20
  member _.AnotherProperty = 30
  
  // 3. Methods - static first, then instance
  static member StaticMethod() = ()
  static member AnotherStatic() = ()
  
  member _.PublicMethod() = ()
  member _.AnotherMethod() = ()
  
  private member _.PrivateHelper() = ()
```