### PR TITLE
Track editorConfig changes for column checks

### DIFF
--- a/src/FSLint/B2R2.FSLint.fsproj
+++ b/src/FSLint/B2R2.FSLint.fsproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Configuration.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="Diagnostics.fs" />
     <Compile Include="Utils.fs" />

--- a/src/FSLint/Configuration.fs
+++ b/src/FSLint/Configuration.fs
@@ -1,0 +1,106 @@
+module B2R2.FSLint.Configuration
+
+open System
+open System.IO
+
+(* TODO: Add Indentation check *)
+type EditorConfig = { MaxLineLength: int }
+
+let defaultSettings = { MaxLineLength = 80 }
+
+let private parseSettings lines (fileName: string) =
+  let processLine (inSection, settings) (line: string) =
+    let trimmed = line.Trim()
+    if trimmed = "" || trimmed.StartsWith("#") || trimmed.StartsWith(";") then
+      inSection, settings
+    elif trimmed.StartsWith("[") && trimmed.EndsWith("]") then
+      let section = trimmed.Trim('[', ']')
+      let matches =
+        section = "*" ||
+        section.Contains "*.fs" && fileName.EndsWith ".fs" ||
+        (section.Contains "{fs,fsi,fsx}" &&
+        (fileName.EndsWith ".fs"))
+      matches, settings
+    elif inSection && trimmed.Contains "=" then
+      let parts = trimmed.Split([| '=' |], 2)
+      if parts.Length = 2 then
+        let key = parts[0].Trim()
+        let value = parts[1].Trim()
+        let newSettings =
+          match key with
+          | "max_line_length" ->
+            match Int32.TryParse value with
+            | true, length when length > 0 ->
+              { settings with MaxLineLength = length }
+            | _ ->
+              settings
+          | _ ->
+            settings
+        inSection, newSettings
+      else
+        inSection, settings
+    else
+      inSection, settings
+  lines
+  |> Array.fold processLine (false, defaultSettings)
+  |> snd
+
+let private readFile (path: string) (maxRetries: int) =
+  let rec attempt retryCount =
+    try
+      use stream = new FileStream(
+        path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite
+      )
+      use reader = new StreamReader(stream)
+      let rec readLines acc =
+        let line = reader.ReadLine()
+        if isNull line then List.rev acc |> Array.ofList
+        else readLines (line :: acc)
+      readLines []
+    with
+    | :? IOException when retryCount < maxRetries ->
+      eprintfn "[EditorConfig] File locked, retry %d/%d..."
+        (retryCount + 1) maxRetries
+      Threading.Thread.Sleep 100
+      attempt (retryCount + 1)
+    | ex ->
+      eprintfn "[EditorConfig] Read error: %s" ex.Message
+      reraise ()
+  attempt 0
+
+let private findEditorConfig (startPath: string) =
+  let rec search (dir: string) =
+    if String.IsNullOrEmpty dir then
+      None
+    else
+      let configPath = Path.Combine(dir, ".editorconfig")
+      if File.Exists configPath then
+        eprintfn "[EditorConfig] Found: %s" configPath
+        Some configPath
+      else
+        let parent = Directory.GetParent dir
+        if isNull parent then
+          eprintfn "[EditorConfig] Not found, searched up to root"
+          None
+        else search parent.FullName
+  search startPath
+
+let getSettings (rootPath: string): EditorConfig =
+  try
+    let dir =
+      if File.Exists rootPath then Path.GetDirectoryName(rootPath)
+      elif Directory.Exists rootPath then rootPath
+      else rootPath
+    match findEditorConfig dir with
+    | Some configPath ->
+      let lines = readFile configPath 5
+      let settings = parseSettings lines "*.fs"
+      eprintfn "[EditorConfig] Loaded from %s:" configPath
+      eprintfn "  max_line_length = %d" settings.MaxLineLength
+      settings
+    | None ->
+      eprintfn "[EditorConfig] Using defaults"
+      defaultSettings
+  with ex ->
+    eprintfn "[EditorConfig] Error reading config: %s" ex.Message
+    defaultSettings

--- a/src/FSLint/DeclarationConvention.fs
+++ b/src/FSLint/DeclarationConvention.fs
@@ -216,8 +216,10 @@ let checkUnnecessaryLineBreak (src: ISourceText) (binding: SynBinding) =
           |> Array.filter (fun line -> line <> "")
         let oneLine = String.concat " " contentParts
         let totalLength = indent + oneLine.Length
-        if totalLength <= MaxLineLength then reportNewLine src body.Range
-        else ()
+        if totalLength <= getCurrentMaxLineLength () then
+          reportNewLine src body.Range
+        else
+          ()
       else
         ()
     | None ->

--- a/src/FSLint/Diagnostics.fs
+++ b/src/FSLint/Diagnostics.fs
@@ -2,6 +2,7 @@ namespace B2R2.FSLint
 
 open System
 open System.IO
+open System.Threading
 open FSharp.Compiler.Text
 
 exception LintException of string
@@ -9,14 +10,23 @@ exception LintException of string
 module Diagnostics =
   let private outputLock = obj ()
 
-  let currentFilePath = new Threading.AsyncLocal<string>()
+  let currentFilePath = new AsyncLocal<string>()
 
-  let currentLintContext = new Threading.AsyncLocal<LintContext option>()
+  let cliEditorConfig = new AsyncLocal<Configuration.EditorConfig>()
+
+  let currentLintContext = new AsyncLocal<LintContext option>()
 
   let setCurrentFile (path: string) = currentFilePath.Value <- path
 
   let setCurrentLintContext (context: LintContext option) =
     currentLintContext.Value <- context
+
+  let setCliEditorConfig config = cliEditorConfig.Value <- config
+
+  let getCurrentMaxLineLength () =
+    match currentLintContext.Value with
+    | Some ctx -> ctx.EditorConfig.MaxLineLength
+    | None -> cliEditorConfig.Value.MaxLineLength
 
   let exitWithError (message: string) =
     Console.WriteLine message

--- a/src/FSLint/LineConvention.fs
+++ b/src/FSLint/LineConvention.fs
@@ -34,19 +34,20 @@ let checkControlChar (src: ISourceText) (lineNum: int) (line: string) =
 
 let check src (txt: string) =
   let hasPassed = checkWindowsLineEndings src txt
+  let maxLineLength = getCurrentMaxLineLength ()
   match hasPassed, currentLintContext.Value with
   | Ok(), Some context ->
     let src = context.Source
     txt.Split([| "\n" |], StringSplitOptions.None)
     |> Array.iteri (fun i line ->
       let lineNum = i + 1
-      if line.Length > MaxLineLength then
+      if line.Length > maxLineLength then
         let range =
           Range.mkRange ""
-            (Position.mkPos lineNum (MaxLineLength - 1))
+            (Position.mkPos lineNum (maxLineLength - 1))
             (Position.mkPos lineNum line.Length)
         reportWarn src range
-          $"exceeds {MaxLineLength} characters."
+          $"exceeds {maxLineLength} characters."
       elif trailingWhiteSpace.IsMatch line then
         let trailingStart = line.TrimEnd().Length
         let range =
@@ -62,11 +63,11 @@ let check src (txt: string) =
     txt.Split([| "\n" |], StringSplitOptions.None)
     |> Array.iteri (fun i line ->
       let lineNum = i + 1
-      if line.Length > MaxLineLength then
+      if line.Length > maxLineLength then
         Console.WriteLine line
         Console.WriteLine(
-          "|" + String.replicate (MaxLineLength - 2) "-" + "|")
-        raiseWithWarn $"Line {i + 1} exceeds {MaxLineLength} characters."
+          "|" + String.replicate (maxLineLength - 2) "-" + "|")
+        raiseWithWarn $"Line {i + 1} exceeds {maxLineLength} characters."
       elif trailingWhiteSpace.IsMatch line then
         Console.WriteLine line
         Console.WriteLine(String.replicate (line.Length - 1) " " + "^")

--- a/src/FSLint/Types.fs
+++ b/src/FSLint/Types.fs
@@ -46,7 +46,8 @@ type LintError =
 and LintContext =
   { mutable Errors: LintError list
     Source: ISourceText
-    FilePath: string }
+    FilePath: string
+    EditorConfig: Configuration.EditorConfig }
 
 and LintOutcome =
   { Index: int

--- a/src/FSLint/Utils.fs
+++ b/src/FSLint/Utils.fs
@@ -5,10 +5,7 @@ open System
 open System.IO
 open System.Text.RegularExpressions
 open FSharp.Compiler.CodeAnalysis
-open FSharp.Compiler.Text
 open FSharp.Compiler.Syntax
-
-let [<Literal>] MaxLineLength = 80
 
 let [<Literal>] FakeFsPath = "FakeFsPathForUnitTest.fs"
 


### PR DESCRIPTION
Close #96 

Real-time checks are performed based on ```.editorconfig``` ```max_line_length```, including warnings for premature line breaks and lines exceeding the column limit. **File changes are tracked using a file watcher.**