### PR TITLE
Fix newline check only for multiline lets

### DIFF
--- a/src/FSLint.Tests/DeclarationTests.fs
+++ b/src/FSLint.Tests/DeclarationTests.fs
@@ -5,14 +5,14 @@ open Microsoft.VisualStudio.TestTools.UnitTesting
 [<TestClass>]
 type DeclarationTests() =
 
-  let goodTopBindingSpacingTest =
+  let goodBindingSingleSpacingTest =
     """
 let foo = 1
 
 let bar = 2
 """
 
-  let badTopBindingSpacingTest =
+  let goodBindingNoSpacingTest =
     """
 let foo = 1
 let bar = 2
@@ -28,8 +28,8 @@ let bar = 2
 
   [<TestMethod>]
   member _.``[ModuleDeclaration] Top Binding Spacing Test``() =
-    lint goodTopBindingSpacingTest
-    lintAssert badTopBindingSpacingTest
+    lint goodBindingSingleSpacingTest
+    lint goodBindingNoSpacingTest
 
   [<TestMethod>]
   member _.``[ModuleDeclaration] Top Binding Too Much Spacing Test``() =

--- a/src/FSLint/DeclarationConvention.fs
+++ b/src/FSLint/DeclarationConvention.fs
@@ -143,14 +143,11 @@ let checkSingleBlankLine (src: ISourceText) decls =
         let actual =
           nextDecl.Range.StartLine - prevDecl.Range.EndLine
           |> adjustByComment prevDecl.Range nextDecl.Range expected
-        if actual <> expected then
-          if expected - actual = 1 then
-            Range.unionRanges prevDecl.Range nextDecl.Range
-            |> fun range -> reportWarn src range "Use single blank line"
-          else
-            Range.mkRange "" (Position.mkPos (prevDecl.Range.EndLine + 1) 0)
-              (Position.mkPos (nextDecl.Range.StartLine - 1) 0)
-            |> fun range -> reportWarn src range "Use single blank line"
+        if expected < actual then
+          (Position.mkPos (prevDecl.Range.EndLine + 1) 0,
+          Position.mkPos (nextDecl.Range.StartLine - 1) 0)
+          ||> Range.mkRange prevDecl.Range.FileName
+          |> fun range -> reportWarn src range "Use at most one blank line"
         else
           ()
       else


### PR DESCRIPTION
This rule is enforced only in strict mode.

Close #124 