### PR TITLE
Add missing cases in ArrayOrListConvention

### DIFF
--- a/src/FSLint/ArrayOrListConvention.fs
+++ b/src/FSLint/ArrayOrListConvention.fs
@@ -215,6 +215,9 @@ let checkMultiLine src range = function
     checkOpeningBracketIsInlineWithLet src range
     collectElemAndOptionalSeparatorRanges [] expr
     |> checkSingleElementPerLine src
+  | SynExpr.Match _
+  | SynExpr.MatchBang _
+  | SynExpr.MatchLambda _
   | SynExpr.ArrayOrListComputed _
   | SynExpr.Ident _
   | SynExpr.Record _


### PR DESCRIPTION
Close #123
  - Checked in ```checkExpression```
