### PR TITLE
Upgrade package to suppress warning

### DIFF
--- a/src/FSLint.LanguageServer/B2R2.FSLint.LanguageServer.fsproj
+++ b/src/FSLint.LanguageServer/B2R2.FSLint.LanguageServer.fsproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StreamJsonRpc" Version="2.25.25" />
+    <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Package 'MessagePack' 2.5.198 has a known high severity vulnerability, https://github.com/advisories/GHSA-hv8m-jj95-wg3x