### PR TITLE
Fix type annotation check for qualified type names

### DIFF
--- a/src/FSLint.Tests/TypeAnnotationTests.fs
+++ b/src/FSLint.Tests/TypeAnnotationTests.fs
@@ -193,6 +193,39 @@ type ITokenContextProvider =
 extern int private cRead(int fd, byte[] buf, int count)
 """
 
+  let goodQualifiedTypeAnnotationTest =
+    """
+type Class() =
+  member _.Foo(sb: System.Text.StringBuilder) = None
+"""
+
+  let badQualifiedTypeAnnotationTest =
+    """
+type Class() =
+  member _.Foo(sb:System.Text.StringBuilder) = None
+"""
+
+  let goodQualifiedTypeFunctionTest =
+    """
+let f (sb: System.Text.StringBuilder) = sb
+"""
+
+  let goodQualifiedTypeTupleTest =
+    """
+let f (a: System.Text.StringBuilder, b: int) = a
+"""
+
+  let goodQualifiedTypeGenericTest =
+    """
+let f (m: System.Collections.Generic.List<int>) = m
+"""
+
+  let badQualifiedTypeSpaceBeforeTest =
+    """
+type Class() =
+  member _.Foo(sb : System.Text.StringBuilder) = None
+"""
+
   [<TestMethod>]
   member _.``Type Annotation Empty Paren Test``() =
     lint goodEmptyParenTest
@@ -270,3 +303,12 @@ extern int private cRead(int fd, byte[] buf, int count)
     lint goodAbstractAnonRecdTest
     lintAssert badAbstractAnonRecdLeftBracketTest
     lintAssert badAbstractAnonRecdRightBracketTest
+
+  [<TestMethod>]
+  member _.``Type Annotation Qualified Type Test``() =
+    lint goodQualifiedTypeAnnotationTest
+    lint goodQualifiedTypeFunctionTest
+    lint goodQualifiedTypeTupleTest
+    lint goodQualifiedTypeGenericTest
+    lintAssert badQualifiedTypeAnnotationTest
+    lintAssert badQualifiedTypeSpaceBeforeTest

--- a/src/FSLint/TypeAnnotationConvention.fs
+++ b/src/FSLint/TypeAnnotationConvention.fs
@@ -481,10 +481,8 @@ let checkWithNullBarSpacing src (innerType: SynType) (barRange: range) =
     ()
 
 let checkPat src (pat: SynPat) = function
-  | SynType.LongIdent(SynLongIdent([ id ], _, _)) ->
-    checkColonSpace src pat.Range id.idRange
-  | SynType.LongIdent(SynLongIdent([ id1; id2 ], _, _)) ->
-    Range.unionRanges id1.idRange id2.idRange
+  | SynType.LongIdent(SynLongIdent(ids, _, _)) when not (List.isEmpty ids) ->
+    Range.unionRanges (List.head ids).idRange (List.last ids).idRange
     |> checkColonSpace src pat.Range
   | SynType.App(range = range) ->
     checkColonSpace src pat.Range range


### PR DESCRIPTION
Close #157 

### Problem

`checkPat` currently hardcodes `SynType.LongIdent` handling for only 1- and 2-segment names.

Because of this, dotted type names with 3 or more segments, such as:

```fsharp
System.Text.StringBuilder