### PR TITLE
Fix FCS trace log

### DIFF
--- a/src/FSLint.LanguageServer/Program.fs
+++ b/src/FSLint.LanguageServer/Program.fs
@@ -442,6 +442,7 @@ type LspServer(rpc: JsonRpc) =
 
 [<EntryPoint>]
 let main _ =
+  Diagnostics.Trace.Listeners.Clear()
   try
     eprintfn "========================================="
     eprintfn "FSLint Language Server Starting"

--- a/src/FSLint/Program.fs
+++ b/src/FSLint/Program.fs
@@ -703,6 +703,7 @@ let linterForProjSln =
 
 [<EntryPoint>]
 let main args =
+  System.Diagnostics.Trace.Listeners.Clear()
   if args.Length < 1 then exitWithError "Usage: fslint <file|dir>"
   else ()
   let rest, opts = OptParse.Parse(spec, "fslint", args, defaultOpts)


### PR DESCRIPTION
Close #169 

## Summary

Both the `fslint` CLI and the FSLint language server emit hundreds of informational messages while parsing:

```text
B2R2.FSLint Information: 0 : FCS: Unknown.parseFile (...)
```

On Linux, these messages are written to stderr and forwarded to journald/syslog, causing significant log flooding. The previous fix in #167 / #168 disabled StreamJsonRpc tracing, but did not resolve the issue.

## Root cause

The messages are emitted by **FSharp.Compiler.Service (FCS)**, not by FSLint or StreamJsonRpc.

FCS calls the static `System.Diagnostics.Trace.TraceInformation` API during operations such as `ParseFile` and `GetProjectOptionsFromScript`. Because static `Trace` uses the process-global `Trace.Listeners`, its output is handled by the default listener and appears under the FSLint process name.

This is separate from StreamJsonRpc's `TraceSource`, so disabling `rpc.TraceSource` has no effect on these messages.

## Fix

Clear the static trace listeners at startup in both entry points:

* `src/FSLint/Program.fs`
* `src/FSLint.LanguageServer/Program.fs`

```fsharp
System.Diagnostics.Trace.Listeners.Clear()
```

FCS does not provide a switch to disable these unconditional trace calls. FSLint's own diagnostics use console output rather than static `Trace`, so lint results and existing diagnostics remain unaffected.

## Verification

After rebuilding and restarting the CLI and language server:

* No `FCS:` messages appear in stderr, journald, or syslog.
* Lint diagnostics are still produced correctly.

This is a follow-up to #167 / #168: the remaining log flood came from FCS's static `Trace` channel, not StreamJsonRpc.
